### PR TITLE
fix(LINGUIST-368): Profile render error fixed

### DIFF
--- a/components/gamification/streak/ChatStreakModal.tsx
+++ b/components/gamification/streak/ChatStreakModal.tsx
@@ -17,7 +17,7 @@ const ChatStreakModal = ({ handleModalClose, handleModalOpen, streakModalVisible
   const { user } = useUser();
 
   useEffect(() => {
-    if (user && isDateToday(user.lastLogin)) {
+    if (user && user.lastLogin && isDateToday(user.lastLogin)) {
       handleModalClose();
     } else {
       handleModalOpen();

--- a/components/user/profile/Profile.tsx
+++ b/components/user/profile/Profile.tsx
@@ -116,10 +116,12 @@ const Profile = () => {
         </Button>
       </View>
 
-      <View style={styles.activityContainer}>
-        <Text style={styles.activityTitle}>Activity</Text>
-        <Text style={styles.lastLogin}>Last login: {user.lastLogin.toLocaleString()}</Text>
-      </View>
+      {user.lastLogin && (
+        <View style={styles.activityContainer}>
+          <Text style={styles.activityTitle}>Activity</Text>
+          <Text style={styles.lastLogin}>Last login: {user.lastLogin.toLocaleString()}</Text>
+        </View>
+      )}
     </ScrollView>
   );
 };


### PR DESCRIPTION
The profile render error only happened when it was the very first time the user logged in, since their last login field would come as undefined. I changed it so that if it is undefined, then we do not show the Activity-Last login fields on the profile. 