### PR TITLE
fix(LINGUIST-376): Word list filtering when no result

### DIFF
--- a/components/word-bank/word-list/WordLists.tsx
+++ b/components/word-bank/word-list/WordLists.tsx
@@ -156,7 +156,7 @@ const WordLists = () => {
     return (
       <View style={styles.wordListContainer}>
         <FlatList
-          data={filteredWordLists.length === 0 ? wordLists?.lists : filteredWordLists}
+          data={filteredWordLists.length > 0 ? filteredWordLists : []}
           renderItem={({ item }) => <WordListCard list={item} handleListSelection={handleListSelection} />}
           numColumns={2}
           keyExtractor={(item) => item.listId}


### PR DESCRIPTION
If no matches are found when filtering, then do not show anything. 