### PR TITLE
fix(LINGUIST-369): User profile updated

### DIFF
--- a/components/user/constants.ts
+++ b/components/user/constants.ts
@@ -37,9 +37,9 @@ export const HOBBIES_LIST = [
 ];
 
 export const ENGLISH_LEVELS = [
-  { value: "DON'T KNOW", label: "I don't know" },
+  { value: "DONT_KNOW", label: "I don't know" },
   { value: 'BEGINNER', label: 'Beginner' },
-  { value: 'INTERMEDIEAET', label: 'Intermediate' },
+  { value: 'INTERMEDIATE', label: 'Intermediate' },
   { value: 'ADVANCED', label: 'Advanced' },
   { value: 'NATIVE', label: 'Native' },
 ];
@@ -60,7 +60,7 @@ export const BOT_MESSAGES: ConversationStep[] = [
     message: 'Nice to meet you! How old are you?',
     skippedMsg: "Okay, let's skip that for now. How old are you?",
     skippable: true,
-    name: 'age',
+    name: 'birthDate',
     trigger: 2,
     type: 'date',
   },

--- a/components/user/onboarding/UserInfoForm.tsx
+++ b/components/user/onboarding/UserInfoForm.tsx
@@ -53,7 +53,7 @@ const UserInfoForm = ({ userDetails }: UserInfoFormProps) => {
       name: data.name,
       englishLevel: data.englishLevel,
       hobbies: data.hobbies,
-      birthDate,
+      birthDate: birthDate,
     };
     await mutate(newProfile);
 
@@ -99,6 +99,9 @@ const UserInfoForm = ({ userDetails }: UserInfoFormProps) => {
             label="English Level"
             dataSet={ENGLISH_LEVELS.map((level) => ({ id: level.value, title: level.label }))}
             initialValue={userDetails.englishLevel ?? null}
+            clearOnFocus={true}
+            showClear={false}
+            showChevron={false}
           />
           <ActionButton
             title={
@@ -112,7 +115,6 @@ const UserInfoForm = ({ userDetails }: UserInfoFormProps) => {
           {isDateSelectionVisible ? (
             <PrimaryDatePicker
               name="birthDate"
-              label="Birth Date"
               rules={{}}
               close={() => setIsDateSelectionVisible(false)}
               defaultValue={userDetails.birthDate ?? new Date()}


### PR DESCRIPTION
Changes:

- User profile can be updated from the profile page
- Onboarding page updates the user profile
- From the profile page's English level dropdown menu, removed the close button since it was too small - it only registered tapping on third, fourth try. Also removed the arrow icon since if something was already selected, the menu only showed what was selected as it is got filtered. Instead, now the field gets cleared when tapped and all options are shown. 

Issues: 

- On the profile page, if the user changes the fields and then presses cancel, all fields are reset except the English level. I think this may be because autocomplete-dropdown's initial value field could not be converted to the defaultValue, but not sure. Need @selimcanglr's help. 
- Pages accessing the update profile endpoint always show a success message, even if the endpoint returns an error on Postman (400 Bad request). 
- If the user skips some questions during the onboarding process, profile does not get updated. This is a backend issue, addressed by [this PR.](https://github.com/LinguistAI/user/pull/60)