### PR TITLE
fix(LINGUIST-363): words set to lowercase

### DIFF
--- a/components/word-bank/WordInfoCard.tsx
+++ b/components/word-bank/WordInfoCard.tsx
@@ -15,7 +15,8 @@ interface WordInfoCardProps {
 }
 
 const WordInfoCard = ({ selectedWord, onDismiss }: WordInfoCardProps) => {
-  const { data, isFetching, isError } = useGetWordMeaningsQuery([selectedWord], { refetchOnFocus: false });
+  const lowercaseWord = selectedWord.toLowerCase();
+  const { data, isFetching, isError } = useGetWordMeaningsQuery([lowercaseWord], { refetchOnFocus: false });
 
   const renderWordDetails = () => {
     let result = null;
@@ -25,7 +26,7 @@ const WordInfoCard = ({ selectedWord, onDismiss }: WordInfoCardProps) => {
       result = <Text>We couldn't fetch the details for this word.</Text>;
     } else {
       const dict = data?.dict!;
-      const wordGroupOrNot = dict[selectedWord];
+      const wordGroupOrNot = dict[lowercaseWord];
       if (isDictionaryWordGroup(wordGroupOrNot)) {
         const wordGroupObj = wordGroupOrNot;
         result = wordGroupObj.wordGroup.map((group) => <WordDetail key={group.id} definition={group} />);


### PR DESCRIPTION
Fixed an issue for words with uppercase letters where their meanings could not be inferred from the dictionary response since dictionary always returns the words as all lowercase. 