### PR TITLE
fix(LINGUIST-532): Prevent multiple chat refreshes

### DIFF
--- a/components/chat/api.ts
+++ b/components/chat/api.ts
@@ -48,6 +48,7 @@ export const chatApi = createApi({
       providesTags: (result, error, args) => [
         { type: 'Message', id: `${args.conversationId}-${args.params.page}-${args.params.pageSize}}` },
       ],
+      keepUnusedDataFor: 0,
     }),
     createNewConversation: builder.mutation<TConversation, string>({
       query: (botId: string) => ({

--- a/components/common/Card.tsx
+++ b/components/common/Card.tsx
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
     },
     shadowOpacity: 0.23,
     shadowRadius: 2.62,
-    elevation: 4,
+    elevation: 12,
   },
 });
 

--- a/screens/chat/ChatScreen.tsx
+++ b/screens/chat/ChatScreen.tsx
@@ -57,6 +57,7 @@ const ChatScreen = ({ route }: ChatScreenProps) => {
   const isPending = isLoadingMessages || isSendingMessage;
 
   useEffect(() => {
+    console.log(isFirstPage);
     if (isFirstPage) {
       scrollViewRef.current?.scrollToEnd({ animated: false });
     }
@@ -135,9 +136,9 @@ const ChatScreen = ({ route }: ChatScreenProps) => {
           automaticallyAdjustContentInsets={true}
           refreshControl={
             <RefreshControl
-              refreshing={isLoadingMessages}
+              refreshing={false}
               onRefresh={() => {
-                if (hasMoreMessages) {
+                if (hasMoreMessages && !isLoadingMessages) {
                   const newPage = currentPage + Math.floor(addedMessages.length / DEFAULT_PAGE_SIZE) + 1;
                   setCurrentPage(newPage);
                 }
@@ -155,7 +156,24 @@ const ChatScreen = ({ route }: ChatScreenProps) => {
                 }}
               >
                 <View style={{ padding: 16 }}>
-                  <Text style={{ textAlign: 'center' }}>No more messages...</Text>
+                  <Text style={{ textAlign: 'center' }}>You reached the start of the conversation!</Text>
+                </View>
+              </Card>
+            </View>
+          )}
+          {hasMoreMessages && !isLoadingMessages && (
+            <View style={{ marginBottom: 32 }}>
+              <Card
+                style={{
+                  width: Dimensions.get('screen').width / 2,
+                  justifyContent: 'center',
+                  alignSelf: 'center',
+                }}
+              >
+                <View style={{ padding: 8 }}>
+                  <Text style={{ textAlign: 'center', fontSize: 13, color: Colors.gray[600] }}>
+                    Pull to load more messages...
+                  </Text>
                 </View>
               </Card>
             </View>

--- a/screens/chat/constants.ts
+++ b/screens/chat/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_PAGE_SIZE = 5;
+export const DEFAULT_PAGE_SIZE = 10;
 export const INITIAL_PAGE = 1;


### PR DESCRIPTION
- Prevents multiple chat refreshes. Removes the native load button and adds custom refresh indicator
- Adds a "pull to load more messages" card to the top
- Removed no more messages and added "You reached the start of the conversation" text.
- Messages are not cached anymore