### PR TITLE
fix(LINGUIST-471): Fixed "Sign Out" button in iOS having incorrect border color

### DIFF
--- a/components/common/form/Button.tsx
+++ b/components/common/form/Button.tsx
@@ -59,7 +59,9 @@ const Button = (props: PrimaryButtonProps) => {
           ...baseButtonStyle,
           {
             backgroundColor: Colors[color][500],
-            borderColor: Colors[color][700],
+            borderBottomColor: Colors[color][700],
+            borderRightColor: Colors[color][700],
+            borderLeftColor: Colors[color][300],
           },
         ];
         }

--- a/components/common/form/Button.tsx
+++ b/components/common/form/Button.tsx
@@ -64,7 +64,7 @@ const Button = (props: PrimaryButtonProps) => {
             borderLeftColor: Colors[color][300],
           },
         ];
-        }
+      }
       if (type === 'outlined') {
         baseButtonStyle = [
           ...baseButtonStyle,


### PR DESCRIPTION
![image](https://github.com/LinguistAI/mobile/assets/86242974/f6a30583-1efc-4d31-9fd5-7d5e42eb0091)